### PR TITLE
Add Instrumentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@
 *.backup
 
 log.txt
+saved_models/
+saved_data/

--- a/src/main.py
+++ b/src/main.py
@@ -30,7 +30,7 @@ signal.signal(signal.SIGINT, signal_handler)
 # b2_player = Player('b',n_b2)
 
 tournament=None
-self_play_batch_size=10000
+self_play_batch_size=5000
 benchmark_batch_size=10
 training_rounds=1000
 mirroring=False
@@ -40,7 +40,7 @@ def get_exploration_factor(game_number):
     return 0.1
 
 def log(msg):
-    with open('../log.txt', 'a') as f:
+    with open('./log.txt', 'a') as f:
         f.write(msg + '\n')
 
 # for round in range(0,training_rounds):
@@ -76,7 +76,7 @@ def self_play_group(count):
 
     for round in range(1,training_rounds):
         print('Benchmarking before round', round)
-
+        stats = []
         for benchmark in [MctsStrategy(1000)]:
             for network in networks:
                 ns = NnStrategy(network, mirroring)
@@ -85,11 +85,19 @@ def self_play_group(count):
                 tournament = Tournament(benchmark_batch_size, [p1, p2])
                 results = tournament.run(False)
                 print('Results for {} vs {}: {}\n'.format(benchmark.get_name(), ns.get_name(), results))
-                log('{},{}:{},{}:{}'.format((round-1) * self_play_batch_size, ns.get_name(), results.get('N', 0), benchmark.get_name(),results.get('B', 0)))
+                stats.append('{},{}:{},{}:{}'.format(ns.get_total_games_trained(), ns.get_name(), results.get('N', 0), benchmark.get_name(), results.get('B', 0)))
 
         for p1,p2 in itertools.combinations(players,2):
             tournament = Tournament(self_play_batch_size, [p1, p2])
-            tournament.run(True)
+            tournament.run(False, training=True)
+
+        print("\nSaving data... Please don't exit yet.")
+        for stat in stats:
+            log(stat)
+
+        for player in players:
+            player.strategy.save()
+        print("Save complete!")
 
         print('- - - - - - - - - -')
 

--- a/src/main.py
+++ b/src/main.py
@@ -13,13 +13,6 @@ from player import Player
 import signal, sys, itertools
 import math
 
-def signal_handler(sig, frame):
-    tournament.close()
-    sys.exit(0)
-
-signal.signal(signal.SIGINT, signal_handler)
-
-
 # networks = [NetworkA(), NetworkB(), NetworkC(), NetworkD()]
 # benchmark_strategies = [RandomStrategy(), MctsStrategy(10), MctsStrategy(50), MctsStrategy(250)]#, MctsStrategy(1000)]
 # networks = [NetworkB()]
@@ -96,11 +89,9 @@ def self_play_group(count):
         print('\n---- Saving ----')
         for stat in stats:
             log(stat)
-
         for player in players:
             player.strategy.save()
         print("Save complete!")
-
 
 # self_play_group(3)
 

--- a/src/main.py
+++ b/src/main.py
@@ -79,7 +79,14 @@ def self_play_group(count):
                 tournament = Tournament(benchmark_batch_size, [p1, p2])
                 results = tournament.run(False)
                 print('Results for {} vs {}: {}\n'.format(benchmark.get_name(), ns.get_name(), results))
-                stats.append('{},{}:{},{}:{}'.format(ns.get_total_games_trained(), ns.get_name(), results.get('N', 0), benchmark.get_name(), results.get('B', 0)))
+                stats.append('{},{},{}:{},{}:{}'.format(
+                    ns.get_total_games_trained(),
+                    ns.get_average_game_think_time(),
+                    ns.get_name(),
+                    results.get('N', 0),
+                    benchmark.get_name(),
+                    results.get('B', 0)
+                ))
 
         print('---- Training ----')
         for p1,p2 in itertools.combinations(players,2):

--- a/src/main.py
+++ b/src/main.py
@@ -79,9 +79,10 @@ def self_play_group(count):
                 tournament = Tournament(benchmark_batch_size, [p1, p2])
                 results = tournament.run(False)
                 print('Results for {} vs {}: {}\n'.format(benchmark.get_name(), ns.get_name(), results))
-                stats.append('{},{},{}:{},{}:{}'.format(
+                stats.append('{},{},{},{}:{},{}:{}'.format(
                     ns.get_total_games_trained(),
                     ns.get_average_game_think_time(),
+                    ns.get_total_number_of_moves(),
                     ns.get_name(),
                     results.get('N', 0),
                     benchmark.get_name(),

--- a/src/main.py
+++ b/src/main.py
@@ -75,7 +75,8 @@ def self_play_group(count):
     players = [Player('B' + str(i), s) for i,s in enumerate(strategies)]
 
     for round in range(1,training_rounds):
-        print('Benchmarking before round', round)
+        print('\n================== Round {} =================='.format(round))
+        print('---- Benchmarking ----')
         stats = []
         for benchmark in [MctsStrategy(1000)]:
             for network in networks:
@@ -87,19 +88,18 @@ def self_play_group(count):
                 print('Results for {} vs {}: {}\n'.format(benchmark.get_name(), ns.get_name(), results))
                 stats.append('{},{}:{},{}:{}'.format(ns.get_total_games_trained(), ns.get_name(), results.get('N', 0), benchmark.get_name(), results.get('B', 0)))
 
+        print('---- Training ----')
         for p1,p2 in itertools.combinations(players,2):
             tournament = Tournament(self_play_batch_size, [p1, p2])
             tournament.run(False, training=True)
 
-        print("\nSaving data... Please don't exit yet.")
+        print('\n---- Saving ----')
         for stat in stats:
             log(stat)
 
         for player in players:
             player.strategy.save()
         print("Save complete!")
-
-        print('- - - - - - - - - -')
 
 
 # self_play_group(3)

--- a/src/mcts/mcts_strategy.py
+++ b/src/mcts/mcts_strategy.py
@@ -88,9 +88,8 @@ class MctsStrategy(Strategy):
     def get_name(self):
         return 'MC_' + str(self.rollout_limit)
 
-    def game_over(self, reward):
+    def game_over(self, reward, training=False):
         pass
 
     def save(self):
         pass
-

--- a/src/nn/network.py
+++ b/src/nn/network.py
@@ -2,13 +2,15 @@ import numpy as np
 from keras.models import Sequential, load_model
 from abc import ABC, abstractmethod
 import os
+import json
 
-save_dir = '../saved_models'
-
+saved_model_dir = './saved_models'
+saved_data_dir = './saved_data'
 
 class Network(ABC):
     def __init__(self, model):
         self.model = model
+        self.total_games_trained = 0
         self.load()
 
     def eval_position(self, board_state):
@@ -22,16 +24,33 @@ class Network(ABC):
         self.model.train_on_batch(inputs, outputs)
 
     def load(self):
-        model_path = os.path.join(save_dir, self.get_save_file())
+        model_path = os.path.join(saved_model_dir, self.get_save_file())
+        data_path = os.path.join(saved_data_dir, self.get_save_file(extension='json'))
+
         if os.path.isfile(model_path):
             self.model = load_model(model_path)
             print(('Loaded model from', model_path))
 
+        if os.path.isfile(data_path):
+            print(('Loaded data from', data_path))
+            with open(data_path, 'r') as infile:
+                data = infile.read()
+                self.total_games_trained = int(json.loads(data)['total_games_trained'])
+
     def save(self):
-        if not os.path.isdir(save_dir):
-            os.makedirs(save_dir)
-        model_path = os.path.join(save_dir, self.get_save_file())
+        if not os.path.isdir(saved_model_dir):
+            os.makedirs(saved_model_dir)
+        model_path = os.path.join(saved_model_dir, self.get_save_file())
         self.model.save(model_path)
+
+        if not os.path.isdir(saved_data_dir):
+            os.makedirs(saved_data_dir)
+        data_path = os.path.join(saved_data_dir, self.get_save_file(extension='json'))
+        with open(data_path, 'w') as outfile:
+            json.dump({ 'total_games_trained': self.total_games_trained }, outfile)
+
+    def completed_training_game(self):
+        self.total_games_trained += 1
 
     def _board_states_to_inputs(self, board_states):
         inputs = np.array(board_states)

--- a/src/nn/network_128x4_64_64.py
+++ b/src/nn/network_128x4_64_64.py
@@ -27,8 +27,8 @@ class NetworkB(Network):
 
         super().__init__(model)
 
-    def get_save_file(self):
-        return 'model_128-4_64_64_B{}.h5'.format(self.id)
+    def get_save_file(self, extension='h5'):
+        return 'model_128-4_64_64_B{}.{}'.format(self.id, extension)
 
     def get_name(self):
         return 'B' + str(self.id)

--- a/src/nn/network_256x4_64_64.py
+++ b/src/nn/network_256x4_64_64.py
@@ -26,8 +26,8 @@ class NetworkE(Network):
 
         super().__init__(model)
 
-    def get_save_file(self):
-        return 'model_256-4_64_64.h5'
+    def get_save_file(self, extension='h5'):
+        return 'model_256-4_64_64.{}'.format(extension)
 
     def get_name(self):
         return 'E'

--- a/src/nn/network_64x2_64x2_64_64.py
+++ b/src/nn/network_64x2_64x2_64_64.py
@@ -38,8 +38,8 @@ class NetworkA(Network):
 
         super().__init__(model)
 
-    def get_save_file(self):
-        return 'model_64-2_64-2_64_64.h5'
+    def get_save_file(self, extension='h5'):
+        return 'model_64-2_64-2_64_64.{}'.format(extension)
 
     def get_name(self):
         return 'A'

--- a/src/nn/network_64x2_64x2_64x2_64.py
+++ b/src/nn/network_64x2_64x2_64x2_64.py
@@ -34,8 +34,8 @@ class NetworkC(Network):
 
         super().__init__(model)
 
-    def get_save_file(self):
-        return 'model_64-2_64-2_64-2_64.h5'
+    def get_save_file(self, extension='h5'):
+        return 'model_64-2_64-2_64-2_64.{}'.format(extension)
 
     def get_name(self):
         return 'C'

--- a/src/nn/network_64x4_64x2_64x2_64.py
+++ b/src/nn/network_64x4_64x2_64x2_64.py
@@ -28,8 +28,8 @@ class NetworkD(Network):
 
         super().__init__(model)
 
-    def get_save_file(self):
-        return 'model_64-4_64-2_64-2_64.h5'
+    def get_save_file(self, extension='h5'):
+        return 'model_64-4_64-2_64-2_64.{}'.format(extension)
 
     def get_name(self):
         return 'D'

--- a/src/nn/nn_minimax_strategy.py
+++ b/src/nn/nn_minimax_strategy.py
@@ -53,7 +53,7 @@ class NnMiniMaxStrategy(Strategy):
     def _get_other_player(self, player_id):
         return next(p for p in self.player_ids if p != player_id)
 
-    def game_over(self, reward):
+    def game_over(self, reward, training=False):
         pass
 
     def save(self):

--- a/src/nn/nn_strategy.py
+++ b/src/nn/nn_strategy.py
@@ -60,11 +60,17 @@ class NnStrategy(Strategy):
 
         self.current_game_moves = []
 
+    def completed_training_game(self):
+        self.network.completed_training_game()
+
     def save(self):
         self.network.save()
 
     def get_name(self):
         return self.network.get_name()
+
+    def get_total_games_trained(self):
+        return self.network.total_games_trained
 
     def _build_board_state(self, game, player_id):
         bs = list([list([1 if v == player_id else 0 if v == Board.EMPTY_CELL else -1 for v in row]) for row in game.board.board])

--- a/src/nn/nn_strategy.py
+++ b/src/nn/nn_strategy.py
@@ -63,7 +63,7 @@ class NnStrategy(Strategy):
             self.current_batch_rewards = []
 
         if training:
-            self.network.training_game_over(self.current_game_think_time)
+            self.network.training_game_over(len(self.current_game_moves), self.current_game_think_time)
 
         self.current_game_think_time = 0.0
         self.current_game_moves = []
@@ -79,6 +79,9 @@ class NnStrategy(Strategy):
 
     def get_average_game_think_time(self):
         return self.network.average_think_time
+
+    def get_total_number_of_moves(self):
+        return self.network.total_number_of_moves
 
     def _build_board_state(self, game, player_id):
         bs = list([list([1 if v == player_id else 0 if v == Board.EMPTY_CELL else -1 for v in row]) for row in game.board.board])

--- a/src/random_strategy.py
+++ b/src/random_strategy.py
@@ -6,7 +6,7 @@ class RandomStrategy(Strategy):
     def move(self, game, player_id):
         return random.choice(game.board.get_valid_moves())
 
-    def game_over(self, reward):
+    def game_over(self, reward, training=False):
         pass
 
     def save(self):

--- a/src/strategy.py
+++ b/src/strategy.py
@@ -9,7 +9,7 @@ class Strategy:
         pass
 
     @abstractmethod
-    def game_over(self, reward):
+    def game_over(self, reward, training=False):
         pass
 
     @abstractmethod

--- a/src/tournament.py
+++ b/src/tournament.py
@@ -35,9 +35,7 @@ class Tournament:
             recent_wins[game.winner] += 1
             for player in self.players:
                 reward = 1 if player.id == game.winner else 0 if game.winner is None else -1
-                player.strategy.game_over(reward)
-                if training:
-                    player.strategy.completed_training_game()
+                player.strategy.game_over(reward, training)
 
             game_number += 1
             if game_number % 5 == 0:

--- a/src/tournament.py
+++ b/src/tournament.py
@@ -9,7 +9,7 @@ class Tournament:
         self.game_count = game_count
         self.players = players
 
-    def run(self, save_on_finish=True, update_handler=None):
+    def run(self, save_on_finish=True, update_handler=None, training=False):
         game_number = 1
         wins = {None:0}
         recent_wins = {None:0}
@@ -36,6 +36,8 @@ class Tournament:
             for player in self.players:
                 reward = 1 if player.id == game.winner else 0 if game.winner is None else -1
                 player.strategy.game_over(reward)
+                if training:
+                    player.strategy.completed_training_game()
 
             game_number += 1
             if game_number % 5 == 0:


### PR DESCRIPTION
Does a few things: 

1. Updates log output to be formatted like: `GP,ATT,TM,NN:NN_W,OPP:OPP_W`
     - Variables:
          - `GP`: Games trained
          - `ATT`: Average thinking time per move of the NN in seconds
          - `TM`: Total moves performed in the trained games
          - `NN`: Neural net used in benchmark
          - `NN_W`: Neural net wins during benchmark
          - `OPP`: Opponent used in benchmark
          - `OPP_W`: Opponent wins in bechmark
    - Note that I haven't written any graphing stuff yet, but thats easy if we have all the data. I figured I should get this out first so we can still train

2. Creates a persistent data store for NNs
     - Stored using JSON
     - Currently captures: `Games trained`, `Average Thinking Time` per game

3. Improves resilience of bugs from stopping & starting the net by saving models and logging info after the current round has been completed.  
     - This way, you can stop in the middle of training and the changes from that round won't be saved. This means that one player wont be trained more than another and logs wont get cluttered.
     - Problems can still arise if execution stops while the middle of saving, but its pretty quick so it shouldn't be an issue

4. Drops batch sizes to 5000
     - In a tournament, each net strategy plays the other 2 net strategies. So a batch size of 5000 means that after one round, each player will have been trained 10000 games. 
 
5. Updates output a bit because I'm a perfectionist. Feel free to let me know if you have any ideas on how to make it better too lol
![image](https://user-images.githubusercontent.com/28009669/87258177-a19c2400-c46f-11ea-99f5-21ea8af5c1f6.png)

